### PR TITLE
feat: more precise pegin verifier status & state machine

### DIFF
--- a/src/bridge/client/cli/client_command.rs
+++ b/src/bridge/client/cli/client_command.rs
@@ -73,32 +73,8 @@ impl ClientCommand {
         loop {
             self.client.sync().await;
 
-            let peg_in_graphs = self.client.get_data().peg_in_graphs.clone();
 
-            for peg_in_graph in peg_in_graphs.iter() {
-                let status = peg_in_graph.depositor_status(&self.client.esplora).await;
-
-                self.client.pre_sign_peg_in(peg_in_graph.id());
-                match status {
-                    PegInDepositorStatus::PegInDepositWait => {
-                        self.client
-                            .broadcast_peg_in_deposit(peg_in_graph.id())
-                            .await
-                    }
-                    PegInDepositorStatus::PegInConfirmWait => {
-                        self.client
-                            .broadcast_peg_in_confirm(peg_in_graph.id())
-                            .await
-                    }
-                    _ => {
-                        println!(
-                            "Peg-in graph {} is in status: {}",
-                            peg_in_graph.id(),
-                            status
-                        );
-                    }
-                }
-            }
+            
 
             let peg_out_graphs = self.client.get_data().peg_out_graphs.clone();
             for peg_out_graph in peg_out_graphs.iter() {

--- a/src/bridge/client/client.rs
+++ b/src/bridge/client/client.rs
@@ -641,7 +641,7 @@ impl BitVMClient {
     pub async fn process_peg_in_as_verifier(&mut self, peg_in_graph: &PegInGraph) {
         if let Some(ref context) = self.verifier_context {
             let status = peg_in_graph.verifier_status(&self.esplora, Some(&context)).await;
-            println!("Status: {}", status);
+
             match status {
                 PegInVerifierStatus::PendingOurNonces => {
                     println!("Pusing nonce");

--- a/src/bridge/graphs/peg_in.rs
+++ b/src/bridge/graphs/peg_in.rs
@@ -72,19 +72,19 @@ pub enum PegInVerifierStatus {
 impl Display for PegInVerifierStatus {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            PegInVerifierStatus::AwaitingDeposit => write!(f, "Waiting for deposit transaction..."),
+            PegInVerifierStatus::AwaitingDeposit => write!(f, "Peg-in deposit transaction not confirmed yet. Wait..."),
             PegInVerifierStatus::ReadyToSubmit => {
-                write!(f, "Peg-in pre-signed, confirm transaction ready.")
+                write!(f, "Peg-in confirm transaction pre-signed. Broadcast confirm transaction?")
             }
-            PegInVerifierStatus::PendingOurNonces => write!(f, "Peg-in pending our nonces."),
+            PegInVerifierStatus::PendingOurNonces => write!(f, "Nonce required. Share peg-in confirm nonce?"),
             PegInVerifierStatus::AwaitingNonces => {
-                write!(f, "Peg-in pending verifier nonces.")
+                write!(f, "Awaiting peg-in confirm nonces. Wait...")
             }
             PegInVerifierStatus::PendingOurSignature => {
-                write!(f, "Peg-in pending our signature.")
+                write!(f, "Signature required. Pre-sign peg-in confirm transaction?")
             }
             PegInVerifierStatus::AwaitingSignatures => {
-                write!(f, "Peg-in pending verifier signatures.")
+                write!(f, "Awaiting peg-in confirm signatures. Wait...")
             }
             PegInVerifierStatus::Complete => write!(f, "Peg-in done."),
         }

--- a/src/bridge/graphs/peg_in.rs
+++ b/src/bridge/graphs/peg_in.rs
@@ -58,20 +58,35 @@ impl Display for PegInDepositorStatus {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub enum PegInVerifierStatus {
-    PegInWait,     // no action required, wait
-    PegInPresign,  // should presign peg-in confirm
-    PegInComplete, // peg-in complete
+    AwaitingDeposit,     // no action required, wait
+    PendingOurNonces,    // the given verifier needs to submit nonces
+    AwaitingNonces,      // the given verifier submitted nonces, awaiting other verifier's nonces
+    PendingOurSignature, // the given verifier needs to submit signature
+    AwaitingSignatures,  // the given verifier submitted signatures, awaiting other verifier's signatures
+    ReadyToSubmit,       // all signatures collected, can now submit
+    Complete,            // peg-in complete
 }
 
 impl Display for PegInVerifierStatus {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            PegInVerifierStatus::PegInWait => write!(f, "No action available. Wait..."),
-            PegInVerifierStatus::PegInPresign => {
-                write!(f, "Signature required. Presign peg-in confirm transaction?")
+            PegInVerifierStatus::AwaitingDeposit => write!(f, "Waiting for deposit transaction..."),
+            PegInVerifierStatus::ReadyToSubmit => {
+                write!(f, "Peg-in pre-signed, confirm transaction ready.")
             }
-            PegInVerifierStatus::PegInComplete => write!(f, "Peg-in complete. Done."),
+            PegInVerifierStatus::PendingOurNonces => write!(f, "Peg-in pending our nonces."),
+            PegInVerifierStatus::AwaitingNonces => {
+                write!(f, "Peg-in pending verifier nonces.")
+            }
+            PegInVerifierStatus::PendingOurSignature => {
+                write!(f, "Peg-in pending our signature.")
+            }
+            PegInVerifierStatus::AwaitingSignatures => {
+                write!(f, "Peg-in pending verifier signatures.")
+            }
+            PegInVerifierStatus::Complete => write!(f, "Peg-in done."),
         }
     }
 }
@@ -114,8 +129,8 @@ pub struct PegInGraph {
     pub peg_in_refund_transaction: PegInRefundTransaction,
     pub peg_in_confirm_transaction: PegInConfirmTransaction,
 
-    n_of_n_presigned: bool,
     n_of_n_public_key: PublicKey,
+    n_of_n_public_keys: Vec<PublicKey>,
     n_of_n_taproot_public_key: XOnlyPublicKey,
 
     pub depositor_public_key: PublicKey,
@@ -127,9 +142,13 @@ pub struct PegInGraph {
 }
 
 impl BaseGraph for PegInGraph {
-    fn network(&self) -> Network { self.network }
+    fn network(&self) -> Network {
+        self.network
+    }
 
-    fn id(&self) -> &String { &self.id }
+    fn id(&self) -> &String {
+        &self.id
+    }
 }
 
 impl PegInGraph {
@@ -179,8 +198,8 @@ impl PegInGraph {
             peg_in_deposit_transaction,
             peg_in_refund_transaction,
             peg_in_confirm_transaction,
-            n_of_n_presigned: false,
             n_of_n_public_key: context.n_of_n_public_key,
+            n_of_n_public_keys: context.n_of_n_public_keys.clone(),
             n_of_n_taproot_public_key: context.n_of_n_taproot_public_key,
             depositor_public_key: context.depositor_public_key,
             depositor_taproot_public_key: context.depositor_taproot_public_key,
@@ -233,6 +252,7 @@ impl PegInGraph {
                 },
                 amount: peg_in_deposit_transaction.tx().output[peg_in_confirm_vout_0].value,
             },
+            self.n_of_n_public_keys.clone(),
         );
 
         PegInGraph {
@@ -242,8 +262,8 @@ impl PegInGraph {
             peg_in_deposit_transaction,
             peg_in_refund_transaction,
             peg_in_confirm_transaction,
-            n_of_n_presigned: false,
             n_of_n_public_key: self.n_of_n_public_key,
+            n_of_n_public_keys: self.n_of_n_public_keys.clone(),
             n_of_n_taproot_public_key: self.n_of_n_taproot_public_key,
             depositor_public_key: self.depositor_public_key,
             depositor_taproot_public_key: self.depositor_taproot_public_key,
@@ -277,35 +297,59 @@ impl PegInGraph {
             &self.connector_z,
             &secret_nonces[&self.peg_in_confirm_transaction.tx().compute_txid()],
         );
-
-        self.n_of_n_presigned = true; // TODO: set to true after collecting all n of n signatures
     }
 
     pub fn peg_in_confirm_transaction_ref(&self) -> &PegInConfirmTransaction {
         &self.peg_in_confirm_transaction
     }
 
-    pub async fn verifier_status(&self, client: &AsyncClient) -> PegInVerifierStatus {
+    pub async fn verifier_status(
+        &self,
+        client: &AsyncClient,
+        verifier: Option<&VerifierContext>,
+    ) -> PegInVerifierStatus {
         let (peg_in_deposit_status, peg_in_confirm_status, _) =
             Self::get_peg_in_statuses(self, client).await;
 
-        if peg_in_deposit_status.is_ok_and(|status| status.confirmed) {
-            if peg_in_confirm_status.is_ok_and(|status| status.confirmed) {
-                // peg in complete
-                return PegInVerifierStatus::PegInComplete;
-            } else {
-                if self.n_of_n_presigned {
-                    // peg-in confirm presigned, wait
-                    return PegInVerifierStatus::PegInWait;
-                } else {
-                    // should presign peg-in confirm
-                    return PegInVerifierStatus::PegInPresign;
-                }
-            }
-        } else {
+        if !peg_in_deposit_status.is_ok_and(|status| status.confirmed) {
             // peg-in deposit not confirmed yet, wait
-            return PegInVerifierStatus::PegInWait;
+            return PegInVerifierStatus::AwaitingDeposit;
         }
+
+        if peg_in_confirm_status.is_ok_and(|status| status.confirmed) {
+            // peg in complete
+            return PegInVerifierStatus::Complete;
+        }
+
+        if let Some(verifier_context) = verifier {
+            if !self
+                .peg_in_confirm_transaction
+                .has_nonce_of(verifier_context)
+            {
+                return PegInVerifierStatus::PendingOurNonces;
+            }
+        }
+
+        if !self.peg_in_confirm_transaction.has_all_nonces() {
+            return PegInVerifierStatus::AwaitingNonces;
+        }
+
+        if let Some(verifier_context) = verifier {
+            if !self
+                .peg_in_confirm_transaction
+                .has_signature_of(verifier_context)
+            {
+                return PegInVerifierStatus::PendingOurSignature;
+            }
+        }
+
+        if !self.peg_in_confirm_transaction.has_all_signatures() {
+            return PegInVerifierStatus::AwaitingSignatures;
+        }
+
+        
+        // we have all signature, but confirm wasn't included in a block yet
+        PegInVerifierStatus::ReadyToSubmit
     }
 
     pub async fn operator_status(&self, client: &AsyncClient) -> PegInOperatorStatus {
@@ -317,7 +361,7 @@ impl PegInGraph {
                 // peg in complete
                 return PegInOperatorStatus::PegInComplete;
             } else {
-                if self.n_of_n_presigned {
+                if self.peg_in_confirm_transaction.has_all_signatures() {
                     // should execute peg-in confirm
                     return PegInOperatorStatus::PegInConfirmAvailable;
                 } else {

--- a/src/bridge/transactions/peg_in_confirm.rs
+++ b/src/bridge/transactions/peg_in_confirm.rs
@@ -187,8 +187,6 @@ impl PegInConfirmTransaction {
         let secret_nonce = push_nonce(self, context, input_index);
         secret_nonces.insert(input_index, secret_nonce);
 
-        println!("Pusing nonce for {}", context.verifier_public_key);
-        
         secret_nonces
     }
 

--- a/src/bridge/transactions/peg_in_confirm.rs
+++ b/src/bridge/transactions/peg_in_confirm.rs
@@ -4,6 +4,7 @@ use bitcoin::{
 use musig2::{secp256k1::schnorr::Signature, PartialSignature, PubNonce, SecNonce};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use crate::bridge::contexts::depositor;
 
 use super::{
     super::{
@@ -25,23 +26,35 @@ pub struct PegInConfirmTransaction {
     prev_outs: Vec<TxOut>,
     prev_scripts: Vec<ScriptBuf>,
 
+    n_of_n_public_keys: Vec<PublicKey>,
+
     musig2_nonces: HashMap<usize, HashMap<PublicKey, PubNonce>>,
     musig2_nonce_signatures: HashMap<usize, HashMap<PublicKey, Signature>>,
     musig2_signatures: HashMap<usize, HashMap<PublicKey, PartialSignature>>,
 }
 
 impl PreSignedTransaction for PegInConfirmTransaction {
-    fn tx(&self) -> &Transaction { &self.tx }
+    fn tx(&self) -> &Transaction {
+        &self.tx
+    }
 
-    fn tx_mut(&mut self) -> &mut Transaction { &mut self.tx }
+    fn tx_mut(&mut self) -> &mut Transaction {
+        &mut self.tx
+    }
 
-    fn prev_outs(&self) -> &Vec<TxOut> { &self.prev_outs }
+    fn prev_outs(&self) -> &Vec<TxOut> {
+        &self.prev_outs
+    }
 
-    fn prev_scripts(&self) -> &Vec<ScriptBuf> { &self.prev_scripts }
+    fn prev_scripts(&self) -> &Vec<ScriptBuf> {
+        &self.prev_scripts
+    }
 }
 
 impl PreSignedMusig2Transaction for PegInConfirmTransaction {
-    fn musig2_nonces(&self) -> &HashMap<usize, HashMap<PublicKey, PubNonce>> { &self.musig2_nonces }
+    fn musig2_nonces(&self) -> &HashMap<usize, HashMap<PublicKey, PubNonce>> {
+        &self.musig2_nonces
+    }
     fn musig2_nonces_mut(&mut self) -> &mut HashMap<usize, HashMap<PublicKey, PubNonce>> {
         &mut self.musig2_nonces
     }
@@ -70,7 +83,12 @@ impl PegInConfirmTransaction {
         connector_z: &ConnectorZ,
         input_0: Input,
     ) -> Self {
-        let mut this = Self::new_for_validation(connector_0, connector_z, input_0);
+        let mut this = Self::new_for_validation(
+            connector_0,
+            connector_z,
+            input_0,
+            context.n_of_n_public_keys.clone(),
+        );
 
         this.push_depositor_signature_input_0(context);
 
@@ -81,6 +99,7 @@ impl PegInConfirmTransaction {
         connector_0: &Connector0,
         connector_z: &ConnectorZ,
         input_0: Input,
+        n_of_n_public_keys: Vec<PublicKey>,
     ) -> Self {
         let input_0_leaf = 1;
         let _input_0 = connector_z.generate_taproot_leaf_tx_in(input_0_leaf, &input_0);
@@ -104,6 +123,7 @@ impl PegInConfirmTransaction {
                 script_pubkey: connector_z.generate_taproot_address().script_pubkey(),
             }],
             prev_scripts: vec![connector_z.generate_taproot_leaf_script(input_0_leaf)],
+            n_of_n_public_keys,
             musig2_nonces: HashMap::new(),
             musig2_nonce_signatures: HashMap::new(),
             musig2_signatures: HashMap::new(),
@@ -167,6 +187,8 @@ impl PegInConfirmTransaction {
         let secret_nonce = push_nonce(self, context, input_index);
         secret_nonces.insert(input_index, secret_nonce);
 
+        println!("Pusing nonce for {}", context.verifier_public_key);
+        
         secret_nonces
     }
 
@@ -184,8 +206,39 @@ impl PegInConfirmTransaction {
         merge_transactions(&mut self.tx, &peg_in_confirm.tx);
         merge_musig2_nonces_and_signatures(self, peg_in_confirm);
     }
+
+    pub fn has_nonce_of(&self, context: &VerifierContext) -> bool {
+        let input_index = 0;
+
+        self.musig2_nonces.contains_key(&input_index)
+            && self.musig2_nonces[&input_index].contains_key(&context.verifier_public_key)
+    }
+    pub fn has_all_nonces(&self) -> bool {
+        let input_index = 0;
+
+        self.n_of_n_public_keys.iter().all(|verifier_key| {
+            self.musig2_nonces.contains_key(&input_index)
+                && self.musig2_nonces[&input_index].contains_key(&verifier_key)
+        })
+    }
+    pub fn has_signature_of(&self, context: &VerifierContext) -> bool {
+        let input_index = 0;
+
+        self.musig2_signatures.contains_key(&input_index)
+            && self.musig2_signatures[&input_index].contains_key(&context.verifier_public_key)
+    }
+    pub fn has_all_signatures(&self) -> bool {
+        let input_index = 0;
+
+        self.n_of_n_public_keys.iter().all(|verifier_key| {
+            self.musig2_signatures.contains_key(&input_index)
+                && self.musig2_signatures[&input_index].contains_key(&verifier_key)
+        })
+    }
 }
 
 impl BaseTransaction for PegInConfirmTransaction {
-    fn finalize(&self) -> Transaction { self.tx.clone() }
+    fn finalize(&self) -> Transaction {
+        self.tx.clone()
+    }
 }


### PR DESCRIPTION
For the peg-ins, all verifiers need to sign off on the PegInConfirm. This PR adds more states to the `PegInVerifierStatus` and adds appropriate actions for them. General flow for a given verifier is:

- If we have not sent our nonces, send them
- wait until all verifiers have sent nonces
- if we have not sent our signature, send it
- wait until all verifiers have sent signatures
- submit the `PegInConfirm`

There is a test that demonstrates the process. Assuming this PR gets merged I will make a follow-up pr to add the peg-in handling to the cli.
