### PR TITLE
feat: construct peg-out graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ alloy = { version = "0.2.1", features = ["full"] }
 clap = { version = "4.5.16", features = ["derive", "cargo", "env"] }
 toml = "0.5.11"
 colored = "2.0.0"
+itertools = "0.13.0"
 
 [dev-dependencies]
 num-bigint = { version = "0.4.4", features = ["rand"] }

--- a/src/bridge/client/client.rs
+++ b/src/bridge/client/client.rs
@@ -18,7 +18,7 @@ use crate::bridge::{
     constants::DestinationNetwork,
     contexts::base::generate_n_of_n_public_key,
     graphs::{
-        base::get_tx_statuses,
+        base::{get_tx_statuses, GraphId},
         peg_in::{PegInDepositorStatus, PegInVerifierStatus},
         peg_out::{CommitmentMessageId, PegOutOperatorStatus},
     },
@@ -63,6 +63,18 @@ pub struct BitVMClientPublicData {
     pub version: u32,
     pub peg_in_graphs: Vec<PegInGraph>,
     pub peg_out_graphs: Vec<PegOutGraph>,
+}
+
+impl BitVMClientPublicData {
+    pub fn get_graph_mut(&mut self, graph_id: &GraphId) -> &mut dyn BaseGraph {
+        if let Some(peg_in) = self.peg_in_graphs.iter_mut().find(|x| x.id() == graph_id) {
+            return peg_in;
+        }
+        if let Some(peg_out) = self.peg_out_graphs.iter_mut().find(|x| x.id() == graph_id) {
+            return peg_out;
+        }
+        panic!("graph id not found");
+    }
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq)]
@@ -185,13 +197,21 @@ impl BitVMClient {
         }
     }
 
-    pub fn get_data(&self) -> &BitVMClientPublicData { return &self.data; }
+    pub fn get_data(&self) -> &BitVMClientPublicData {
+        return &self.data;
+    }
 
-    pub async fn sync(&mut self) { self.read().await; }
+    pub async fn sync(&mut self) {
+        self.read().await;
+    }
 
-    pub async fn sync_l2(&mut self) { self.read_from_l2().await; }
+    pub async fn sync_l2(&mut self) {
+        self.read_from_l2().await;
+    }
 
-    pub async fn flush(&mut self) { self.save().await; }
+    pub async fn flush(&mut self) {
+        self.save().await;
+    }
 
     /*
      1. Fetch the lates file
@@ -644,18 +664,34 @@ impl BitVMClient {
 
     pub async fn process_peg_in_as_verifier(&mut self, peg_in_graph: &PegInGraph) {
         if let Some(ref context) = self.verifier_context {
+            let peg_outs = peg_in_graph
+                .peg_out_graphs
+                .iter()
+                .map(|peg_out_id| {
+                    self.data
+                        .peg_out_graphs
+                        .iter()
+                        .find(|x| x.id() == peg_out_id)
+                        .unwrap()
+                })
+                .collect::<Vec<_>>();
+
             let status = peg_in_graph
-                .verifier_status(&self.esplora, Some(&context))
+                .verifier_status(&self.esplora, Some(&context), &peg_outs)
                 .await;
 
             match status {
-                PegInVerifierStatus::PendingOurNonces => {
-                    println!("Pushing nonce");
-                    self.push_peg_in_nonces(&peg_in_graph.id());
+                PegInVerifierStatus::PendingOurNonces(graph_ids) => {
+                    println!("Pushing nonces for graphs {graph_ids:?}");
+                    for graph_id in graph_ids {
+                        self.push_verifier_nonces(&graph_id);
+                    }
                 }
-                PegInVerifierStatus::PendingOurSignature => {
-                    println!("Pushing signature");
-                    self.pre_sign_peg_in(&peg_in_graph.id());
+                PegInVerifierStatus::PendingOurSignature(graph_ids) => {
+                    println!("Pushing signature for graphs {graph_ids:?}");
+                    for graph_id in graph_ids {
+                        self.push_verifier_signature(&graph_id);
+                    }
                 }
                 PegInVerifierStatus::ReadyToSubmit => {
                     println!("Broadcasting peg-in confirm");
@@ -668,12 +704,51 @@ impl BitVMClient {
         }
     }
 
+    pub async fn process_peg_in_as_operator(&mut self, peg_in_graph: &PegInGraph) {
+        if let Some(ref context) = self.operator_context {
+            let peg_out_graph_id = peg_out_generate_id(peg_in_graph, &context.operator_public_key);
+            if !peg_in_graph
+                .peg_out_graphs
+                .iter()
+                .any(|x| x == &peg_out_graph_id)
+            {
+                let input = {
+                    // todo: don't use a random address
+                    let address = generate_pay_to_pubkey_script_address(
+                        context.network,
+                        &context.operator_public_key,
+                    );
+                    let utxos = self
+                        .esplora
+                        .get_address_utxo(address.clone())
+                        .await
+                        .unwrap();
+                    let utxo = utxos
+                        .into_iter()
+                        .find(|x| x.value.to_sat() >= 300000)
+                        .unwrap_or_else(|| {
+                            panic!("No utxo found with at least 300000 sats for address {address}")
+                        });
+                    Input {
+                        amount: utxo.value,
+                        outpoint: OutPoint {
+                            txid: utxo.txid,
+                            vout: utxo.vout,
+                        },
+                    }
+                };
+                self.create_peg_out_graph(&peg_in_graph.id(), input).await;
+            }
+        }
+    }
+
     pub async fn process_peg_ins(&mut self) {
         let peg_in_graphs = self.get_data().peg_in_graphs.clone();
 
         for peg_in_graph in peg_in_graphs {
             self.process_peg_in_as_depositor(&peg_in_graph).await;
             self.process_peg_in_as_verifier(&peg_in_graph).await;
+            self.process_peg_in_as_operator(&peg_in_graph).await;
         }
     }
 
@@ -703,13 +778,7 @@ impl BitVMClient {
                 PegOutOperatorStatus::PegOutTake2Available => {
                     self.broadcast_take_2(peg_out_graph.id()).await
                 }
-                _ => {
-                    println!(
-                        "Peg-out graph {} is in status: {}",
-                        peg_out_graph.id(),
-                        status
-                    );
-                }
+                _ => {}
             }
         }
     }
@@ -720,16 +789,23 @@ impl BitVMClient {
         }
 
         for peg_in_graph in self.data.peg_in_graphs.iter() {
+            let peg_outs = peg_in_graph
+                .peg_out_graphs
+                .iter()
+                .map(|peg_out_id| {
+                    self.data
+                        .peg_out_graphs
+                        .iter()
+                        .find(|x| x.id() == peg_out_id)
+                        .unwrap()
+                })
+                .collect::<Vec<_>>();
             let status = peg_in_graph
-                .verifier_status(&self.esplora, self.verifier_context.as_ref())
+                .verifier_status(&self.esplora, self.verifier_context.as_ref(), &peg_outs)
                 .await;
             println!("Graph id: {} status: {}\n", peg_in_graph.id(), status);
         }
 
-        for peg_out_graph in self.data.peg_out_graphs.iter() {
-            let status = peg_out_graph.verifier_status(&self.esplora).await;
-            println!("Graph id: {} status: {}\n", peg_out_graph.id(), status);
-        }
     }
 
     pub async fn create_peg_in_graph(&mut self, input: Input, evm_address: &str) -> String {
@@ -808,13 +884,11 @@ impl BitVMClient {
         let peg_in_graph = self
             .data
             .peg_in_graphs
-            .iter()
-            .find(|&peg_in_graph| peg_in_graph.id().eq(peg_in_graph_id));
-        if peg_in_graph.is_none() {
-            panic!("Invalid graph id");
-        }
+            .iter_mut()
+            .find(|peg_in_graph| peg_in_graph.id().eq(peg_in_graph_id))
+            .unwrap_or_else(|| panic!("Invalid graph id"));
 
-        let peg_out_graph_id = peg_out_generate_id(peg_in_graph.unwrap(), operator_public_key);
+        let peg_out_graph_id = peg_out_generate_id(peg_in_graph, operator_public_key);
         let peg_out_graph = self
             .data
             .peg_out_graphs
@@ -826,7 +900,7 @@ impl BitVMClient {
 
         let (peg_out_graph, commitment_secrets) = PegOutGraph::new(
             self.operator_context.as_ref().unwrap(),
-            peg_in_graph.unwrap(),
+            peg_in_graph,
             kickoff_input,
         );
 
@@ -837,6 +911,7 @@ impl BitVMClient {
         Self::save_local_private_file(&self.file_path, &serialize(&self.private_data));
 
         self.data.peg_out_graphs.push(peg_out_graph);
+        peg_in_graph.peg_out_graphs.push(peg_out_graph_id.clone());
 
         peg_out_graph_id
     }
@@ -1175,59 +1250,22 @@ impl BitVMClient {
             .unwrap()
     }
 
-    pub fn push_peg_in_nonces(&mut self, peg_in_graph_id: &str) {
+    pub fn push_verifier_nonces(&mut self, graph_id: &GraphId) {
         if self.verifier_context.is_none() {
             panic!("Can only be called by a verifier!");
         }
 
-        let peg_in_graph = self
-            .data
-            .peg_in_graphs
-            .iter_mut()
-            .find(|peg_in_graph| peg_in_graph.id().eq(peg_in_graph_id));
-        if peg_in_graph.is_none() {
-            panic!("Invalid graph id");
-        }
+        let graph = self.data.get_graph_mut(&graph_id);
+        let graph_id = graph.id().clone();
 
-        let secret_nonces = peg_in_graph
-            .unwrap()
-            .push_nonces(&self.verifier_context.as_ref().unwrap());
-
-        self.merge_secret_nonces(peg_in_graph_id, secret_nonces);
+        let secret_nonces = graph.push_verifier_nonces(&self.verifier_context.as_ref().unwrap());
+        self.merge_secret_nonces(&graph_id, secret_nonces);
 
         // TODO: Save secret nonces for all txs in the graph to the local file system. Later, when pre-signing the tx,
         // we'll need to retrieve these nonces for this graph ID.
 
         let json = serialize(&self.private_data);
         Self::save_local_private_file(&self.file_path, &json);
-    }
-
-    pub fn push_peg_out_nonces(&mut self, peg_out_graph_id: &str) {
-        if self.verifier_context.is_none() {
-            panic!("Can only be called by a verifier!");
-        }
-
-        let peg_out_graph = self
-            .data
-            .peg_out_graphs
-            .iter_mut()
-            .find(|peg_out_graph| peg_out_graph.id().eq(peg_out_graph_id));
-        if peg_out_graph.is_none() {
-            panic!("Invalid graph id");
-        }
-
-        let secret_nonces = peg_out_graph
-            .unwrap()
-            .push_nonces(&self.verifier_context.as_ref().unwrap());
-
-        self.merge_secret_nonces(peg_out_graph_id, secret_nonces);
-
-        // TODO: Save secret nonces for all txs in the graph to the local file system. Later, when pre-signing the tx,
-        // we'll need to retrieve these nonces for this graph ID.
-        let json = serialize(&self.private_data);
-        Self::save_local_private_file(&self.file_path, &json);
-
-        // TODO: Add public nonces in the remaining txs in this graph.
     }
 
     fn merge_secret_nonces(
@@ -1268,45 +1306,19 @@ impl BitVMClient {
             .extend(secret_nonces);
     }
 
-    pub fn pre_sign_peg_in(&mut self, peg_in_graph_id: &str) {
-        if self.operator_context.is_none() && self.verifier_context.is_none() {
-            panic!("Can only be called by an operator or a verifier!");
-        }
+    pub fn push_verifier_signature(&mut self, graph_id: &GraphId) {
+        let verifier = self
+            .verifier_context
+            .as_ref()
+            .expect("Can only be called by a verifier!");
 
-        let peg_in_graph = self
-            .data
-            .peg_in_graphs
-            .iter_mut()
-            .find(|peg_in_graph| peg_in_graph.id().eq(peg_in_graph_id));
-        if peg_in_graph.is_none() {
-            panic!("Invalid graph id");
-        }
+        let graph = self.data.get_graph_mut(&graph_id);
+        let graph_id = graph.id().clone();
 
-        peg_in_graph.unwrap().pre_sign(
-            &self.verifier_context.as_ref().unwrap(),
+        graph.verifier_sign(
+            verifier,
             &self.private_data.secret_nonces
-                [&self.verifier_context.as_ref().unwrap().verifier_public_key][peg_in_graph_id],
-        );
-    }
-
-    pub fn pre_sign_peg_out(&mut self, peg_out_graph_id: &str) {
-        if self.operator_context.is_none() && self.verifier_context.is_none() {
-            panic!("Can only be called by an operator or a verifier!");
-        }
-
-        let peg_out_graph = self
-            .data
-            .peg_out_graphs
-            .iter_mut()
-            .find(|peg_out_graph| peg_out_graph.id().eq(peg_out_graph_id));
-        if peg_out_graph.is_none() {
-            panic!("Invalid graph id");
-        }
-
-        peg_out_graph.unwrap().pre_sign(
-            &self.verifier_context.as_ref().unwrap(),
-            &self.private_data.secret_nonces
-                [&self.verifier_context.as_ref().unwrap().verifier_public_key][peg_out_graph_id],
+                [&self.verifier_context.as_ref().unwrap().verifier_public_key][&graph_id],
         );
     }
 
@@ -1341,7 +1353,7 @@ impl BitVMClient {
     }
 
     fn read_local_private_file(file_path: &String) -> Option<String> {
-        println!("Reading private data from local file...");
+        eprintln!("Reading private data from local file...");
         match fs::read_to_string(format!("{file_path}/private/{PRIVATE_DATA_FILE_NAME}")) {
             Ok(content) => Some(content),
             Err(e) => {

--- a/src/bridge/graphs/base.rs
+++ b/src/bridge/graphs/base.rs
@@ -1,6 +1,13 @@
+use std::collections::HashMap;
+
 use bitcoin::{Network, Transaction, Txid};
 use esplora_client::{AsyncClient, Error, TxStatus};
 use futures::future::join_all;
+use musig2::SecNonce;
+
+use crate::bridge::contexts::verifier::VerifierContext;
+
+pub const NUM_REQUIRED_OPERATORS: usize = 1;
 
 pub const GRAPH_VERSION: &str = "0.1";
 
@@ -33,9 +40,20 @@ pub const WITHDRAWER_SECRET: &str =
 pub const DEPOSITOR_EVM_ADDRESS: &str = "0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd";
 pub const WITHDRAWER_EVM_ADDRESS: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 
+pub type GraphId = String;
+
 pub trait BaseGraph {
     fn network(&self) -> Network;
     fn id(&self) -> &String;
+    fn push_verifier_nonces(
+        &mut self,
+        verifier_context: &VerifierContext,
+    ) -> HashMap<Txid, HashMap<usize, SecNonce>>;
+    fn verifier_sign(
+        &mut self,
+        verifier_context: &VerifierContext,
+        secret_nonces: &HashMap<Txid, HashMap<usize, SecNonce>>,
+    );
 }
 
 pub async fn get_block_height(client: &AsyncClient) -> u32 {

--- a/src/bridge/graphs/peg_in.rs
+++ b/src/bridge/graphs/peg_in.rs
@@ -3,6 +3,7 @@ use bitcoin::{
     Network, OutPoint, PublicKey, Transaction, Txid, XOnlyPublicKey,
 };
 use esplora_client::{AsyncClient, Error, TxStatus};
+use itertools::Itertools;
 use musig2::SecNonce;
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
@@ -12,8 +13,11 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 
-use crate::bridge::client::sdk::{
-    query::GraphCliQuery, query_contexts::depositor_signatures::DepositorSignatures,
+use crate::bridge::{
+    client::sdk::{
+        query::GraphCliQuery, query_contexts::depositor_signatures::DepositorSignatures,
+    },
+    transactions::pre_signed_musig2::PreSignedMusig2Transaction,
 };
 
 use super::{
@@ -29,7 +33,11 @@ use super::{
             pre_signed::PreSignedTransaction,
         },
     },
-    base::{broadcast_and_verify, get_tx_statuses, verify_if_not_mined, BaseGraph, GRAPH_VERSION},
+    base::{
+        broadcast_and_verify, get_tx_statuses, verify_if_not_mined, BaseGraph, GraphId,
+        GRAPH_VERSION, NUM_REQUIRED_OPERATORS,
+    },
+    peg_out::{PegOutGraph, PegOutId},
 };
 
 pub enum PegInDepositorStatus {
@@ -64,10 +72,11 @@ impl Display for PegInDepositorStatus {
 
 #[derive(Debug, PartialEq)]
 pub enum PegInVerifierStatus {
-    AwaitingDeposit,     // no action required, wait
-    PendingOurNonces,    // the given verifier needs to submit nonces
-    AwaitingNonces,      // the given verifier submitted nonces, awaiting other verifier's nonces
-    PendingOurSignature, // the given verifier needs to submit signature
+    AwaitingDeposit,                   // no action required, wait
+    AwaitingPegOutCreation,            // need operator(s) to come online to create peg-out grah
+    PendingOurNonces(Vec<GraphId>),    // the given verifier needs to submit nonces
+    AwaitingNonces, // the given verifier submitted nonces, awaiting other verifier's nonces
+    PendingOurSignature(Vec<GraphId>), // the given verifier needs to submit signature
     AwaitingSignatures, // the given verifier submitted signatures, awaiting other verifier's signatures
     ReadyToSubmit,      // all signatures collected, can now submit
     Complete,           // peg-in complete
@@ -79,23 +88,23 @@ impl Display for PegInVerifierStatus {
             PegInVerifierStatus::AwaitingDeposit => {
                 write!(f, "Peg-in deposit transaction not confirmed yet. Wait...")
             }
+            PegInVerifierStatus::AwaitingPegOutCreation => {
+                write!(f, "No peg-out graph available yet. Wait...")
+            }
             PegInVerifierStatus::ReadyToSubmit => {
                 write!(
                     f,
                     "Peg-in confirm transaction pre-signed. Broadcast confirm transaction?"
                 )
             }
-            PegInVerifierStatus::PendingOurNonces => {
-                write!(f, "Nonce required. Share peg-in confirm nonce?")
+            PegInVerifierStatus::PendingOurNonces(_) => {
+                write!(f, "Nonce required. Share nonce?")
             }
             PegInVerifierStatus::AwaitingNonces => {
-                write!(f, "Awaiting peg-in confirm nonces. Wait...")
+                write!(f, "Awaiting nonces. Wait...")
             }
-            PegInVerifierStatus::PendingOurSignature => {
-                write!(
-                    f,
-                    "Signature required. Pre-sign peg-in confirm transaction?"
-                )
+            PegInVerifierStatus::PendingOurSignature(_) => {
+                write!(f, "Signature required. Pre-sign transactions?")
             }
             PegInVerifierStatus::AwaitingSignatures => {
                 write!(f, "Awaiting peg-in confirm signatures. Wait...")
@@ -153,12 +162,42 @@ pub struct PegInGraph {
 
     connector_0: Connector0,
     connector_z: ConnectorZ,
+
+    pub peg_out_graphs: Vec<PegOutId>,
 }
 
 impl BaseGraph for PegInGraph {
-    fn network(&self) -> Network { self.network }
+    fn network(&self) -> Network {
+        self.network
+    }
 
-    fn id(&self) -> &String { &self.id }
+    fn id(&self) -> &String {
+        &self.id
+    }
+
+    fn verifier_sign(
+        &mut self,
+        verifier_context: &VerifierContext,
+        secret_nonces: &HashMap<Txid, HashMap<usize, SecNonce>>,
+    ) {
+        self.peg_in_confirm_transaction.pre_sign(
+            verifier_context,
+            &self.connector_z,
+            &secret_nonces[&self.peg_in_confirm_transaction.tx().compute_txid()],
+        );
+    }
+
+    fn push_verifier_nonces(
+        &mut self,
+        verifier_context: &VerifierContext,
+    ) -> HashMap<Txid, HashMap<usize, SecNonce>> {
+        [(
+            self.peg_in_confirm_transaction.tx().compute_txid(),
+            self.peg_in_confirm_transaction
+                .push_nonces(verifier_context),
+        )]
+        .into()
+    }
 }
 
 impl PegInGraph {
@@ -203,6 +242,7 @@ impl PegInGraph {
             depositor_evm_address: evm_address.to_string(),
             connector_0: connectors.connector_0,
             connector_z: connectors.connector_z,
+            peg_out_graphs: Vec::new(),
         }
     }
 
@@ -287,6 +327,7 @@ impl PegInGraph {
             depositor_evm_address: depositor_evm_address.to_string(),
             connector_0: connectors.connector_0,
             connector_z: connectors.connector_z,
+            peg_out_graphs: Vec::new(),
         }
     }
 
@@ -306,32 +347,6 @@ impl PegInGraph {
         )
     }
 
-    pub fn push_nonces(
-        &mut self,
-        context: &VerifierContext,
-    ) -> HashMap<Txid, HashMap<usize, SecNonce>> {
-        let mut secret_nonces = HashMap::new();
-
-        secret_nonces.insert(
-            self.peg_in_confirm_transaction.tx().compute_txid(),
-            self.peg_in_confirm_transaction.push_nonces(context),
-        );
-
-        secret_nonces
-    }
-
-    pub fn pre_sign(
-        &mut self,
-        context: &VerifierContext,
-        secret_nonces: &HashMap<Txid, HashMap<usize, SecNonce>>,
-    ) {
-        self.peg_in_confirm_transaction.pre_sign(
-            context,
-            &self.connector_z,
-            &secret_nonces[&self.peg_in_confirm_transaction.tx().compute_txid()],
-        );
-    }
-
     pub fn peg_in_confirm_transaction_ref(&self) -> &PegInConfirmTransaction {
         &self.peg_in_confirm_transaction
     }
@@ -340,7 +355,15 @@ impl PegInGraph {
         &self,
         client: &AsyncClient,
         verifier: Option<&VerifierContext>,
+        peg_outs: &[&PegOutGraph],
     ) -> PegInVerifierStatus {
+        // check that the supplied peg out graphs match our expectation
+        let supplied_peg_out_ids = peg_outs.iter().map(|x| x.id()).sorted().collect::<Vec<_>>();
+        let expected_peg_out_ids = self.peg_out_graphs.iter().sorted().collect::<Vec<_>>();
+        if supplied_peg_out_ids != expected_peg_out_ids {
+            panic!("Invalid peg outs supplied as argument");
+        }
+
         let (peg_in_deposit_status, peg_in_confirm_status, _) =
             Self::get_peg_in_statuses(self, client).await;
 
@@ -349,34 +372,62 @@ impl PegInGraph {
             return PegInVerifierStatus::AwaitingDeposit;
         }
 
+        if peg_outs.len() < NUM_REQUIRED_OPERATORS {
+            return PegInVerifierStatus::AwaitingPegOutCreation;
+        }
+
         if peg_in_confirm_status.is_ok_and(|status| status.confirmed) {
             // peg in complete
             return PegInVerifierStatus::Complete;
         }
 
         if let Some(verifier_context) = verifier {
+            let mut peg_outs_without_nonces = peg_outs
+                .iter()
+                .filter(|x| !x.has_all_nonces_of(verifier_context))
+                .map(|x| x.id().clone())
+                .collect::<Vec<_>>();
             if !self
                 .peg_in_confirm_transaction
                 .has_nonce_of(verifier_context)
             {
-                return PegInVerifierStatus::PendingOurNonces;
+                peg_outs_without_nonces.push(self.id().clone());
+            }
+            if !peg_outs_without_nonces.is_empty() {
+                return PegInVerifierStatus::PendingOurNonces(peg_outs_without_nonces);
             }
         }
 
-        if !self.peg_in_confirm_transaction.has_all_nonces() {
+        let has_all_pegin_nonces = self.peg_in_confirm_transaction.has_all_nonces();
+        let has_all_pegout_nonces = peg_outs
+            .iter()
+            .any(|peg_out| peg_out.has_all_nonces(&self.n_of_n_public_keys));
+        if !has_all_pegin_nonces || !has_all_pegout_nonces {
             return PegInVerifierStatus::AwaitingNonces;
         }
 
         if let Some(verifier_context) = verifier {
+            let mut peg_outs_without_signatures = peg_outs
+                .iter()
+                .filter(|x| !x.has_all_signatures_of(verifier_context))
+                .map(|x| x.id().clone())
+                .collect::<Vec<_>>();
             if !self
                 .peg_in_confirm_transaction
-                .has_signature_of(verifier_context)
+                .has_signatures_for(verifier_context.verifier_public_key)
             {
-                return PegInVerifierStatus::PendingOurSignature;
+                peg_outs_without_signatures.push(self.id().clone());
+            }
+            if !peg_outs_without_signatures.is_empty() {
+                return PegInVerifierStatus::PendingOurSignature(peg_outs_without_signatures);
             }
         }
 
-        if !self.peg_in_confirm_transaction.has_all_signatures() {
+        let has_all_pegin_signatures = self.peg_in_confirm_transaction.has_all_signatures();
+        let has_all_pegout_signatures = peg_outs
+            .iter()
+            .any(|peg_out| peg_out.has_all_signatures(&self.n_of_n_public_keys));
+        if !has_all_pegin_signatures || !has_all_pegout_signatures {
             return PegInVerifierStatus::AwaitingSignatures;
         }
 
@@ -595,6 +646,11 @@ impl PegInGraph {
     pub fn merge(&mut self, source_peg_in_graph: &PegInGraph) {
         self.peg_in_confirm_transaction
             .merge(&source_peg_in_graph.peg_in_confirm_transaction);
+
+        self.peg_out_graphs
+            .extend(source_peg_in_graph.peg_out_graphs.clone());
+        self.peg_out_graphs.sort();
+        self.peg_out_graphs.dedup();
     }
 }
 
@@ -705,6 +761,7 @@ fn create_graph_without_signing(
         depositor_evm_address: depositor_evm_address.to_string(),
         connector_0: connectors.connector_0,
         connector_z: connectors.connector_z,
+        peg_out_graphs: Vec::new(),
     }
 }
 

--- a/src/bridge/graphs/peg_out.rs
+++ b/src/bridge/graphs/peg_out.rs
@@ -19,7 +19,10 @@ use crate::bridge::{
         find_superblock, get_start_time_block_number, get_superblock_hash_message_digits,
         get_superblock_message_digits,
     },
-    transactions::signing_winternitz::{WinternitzPublicKeyVariant, WinternitzSingingInputs},
+    transactions::{
+        pre_signed_musig2::PreSignedMusig2Transaction,
+        signing_winternitz::{WinternitzPublicKeyVariant, WinternitzSingingInputs},
+    },
 };
 
 use super::{
@@ -54,9 +57,14 @@ use super::{
             take_2::Take2Transaction,
         },
     },
-    base::{broadcast_and_verify, get_block_height, verify_if_not_mined, BaseGraph, GRAPH_VERSION},
+    base::{
+        broadcast_and_verify, get_block_height, verify_if_not_mined, BaseGraph, GraphId,
+        GRAPH_VERSION,
+    },
     peg_in::PegInGraph,
 };
+
+pub type PegOutId = GraphId;
 
 pub enum PegOutWithdrawerStatus {
     PegOutNotStarted, // peg-out transaction not created yet
@@ -283,9 +291,74 @@ pub struct PegOutGraph {
 }
 
 impl BaseGraph for PegOutGraph {
-    fn network(&self) -> Network { self.network }
+    fn network(&self) -> Network {
+        self.network
+    }
 
-    fn id(&self) -> &String { &self.id }
+    fn id(&self) -> &String {
+        &self.id
+    }
+
+    fn verifier_sign(
+        &mut self,
+        verifier_context: &VerifierContext,
+        secret_nonces: &HashMap<Txid, HashMap<usize, SecNonce>>,
+    ) {
+        self.assert_transaction.pre_sign(
+            verifier_context,
+            &self.connector_b,
+            &secret_nonces[&self.assert_transaction.tx().compute_txid()],
+        );
+        self.disprove_chain_transaction.pre_sign(
+            verifier_context,
+            &self.connector_b,
+            &secret_nonces[&self.disprove_chain_transaction.tx().compute_txid()],
+        );
+        self.disprove_transaction.pre_sign(
+            verifier_context,
+            &self.connector_5,
+            &secret_nonces[&self.disprove_transaction.tx().compute_txid()],
+        );
+        self.kick_off_timeout_transaction.pre_sign(
+            verifier_context,
+            &self.connector_1,
+            &secret_nonces[&self.kick_off_timeout_transaction.tx().compute_txid()],
+        );
+        self.start_time_timeout_transaction.pre_sign(
+            verifier_context,
+            &self.connector_1,
+            &self.connector_2,
+            &secret_nonces[&self.start_time_timeout_transaction.tx().compute_txid()],
+        );
+        self.take_1_transaction.pre_sign(
+            verifier_context,
+            &self.connector_0,
+            &self.connector_b,
+            &secret_nonces[&self.take_1_transaction.tx().compute_txid()],
+        );
+        self.take_2_transaction.pre_sign(
+            verifier_context,
+            &self.connector_0,
+            &self.connector_5,
+            &secret_nonces[&self.take_2_transaction.tx().compute_txid()],
+        );
+
+        self.n_of_n_presigned = true; // TODO: set to true after collecting all n of n signatures
+    }
+
+    fn push_verifier_nonces(
+        &mut self,
+        verifier_context: &VerifierContext,
+    ) -> HashMap<Txid, HashMap<usize, SecNonce>> {
+        self.all_presigned_txs_mut()
+            .map(|tx_wrapper| {
+                (
+                    tx_wrapper.tx().compute_txid(),
+                    tx_wrapper.push_nonces(verifier_context),
+                )
+            })
+            .collect()
+    }
 }
 
 impl PegOutGraph {
@@ -906,91 +979,6 @@ impl PegOutGraph {
             peg_out_chain_event: None,
             peg_out_transaction: None,
         }
-    }
-
-    pub fn push_nonces(
-        &mut self,
-        context: &VerifierContext,
-    ) -> HashMap<Txid, HashMap<usize, SecNonce>> {
-        let mut secret_nonces = HashMap::new();
-
-        secret_nonces.insert(
-            self.assert_transaction.tx().compute_txid(),
-            self.assert_transaction.push_nonces(context),
-        );
-        secret_nonces.insert(
-            self.disprove_chain_transaction.tx().compute_txid(),
-            self.disprove_chain_transaction.push_nonces(context),
-        );
-        secret_nonces.insert(
-            self.disprove_transaction.tx().compute_txid(),
-            self.disprove_transaction.push_nonces(context),
-        );
-        secret_nonces.insert(
-            self.kick_off_timeout_transaction.tx().compute_txid(),
-            self.kick_off_timeout_transaction.push_nonces(context),
-        );
-        secret_nonces.insert(
-            self.start_time_timeout_transaction.tx().compute_txid(),
-            self.start_time_timeout_transaction.push_nonces(context),
-        );
-        secret_nonces.insert(
-            self.take_1_transaction.tx().compute_txid(),
-            self.take_1_transaction.push_nonces(context),
-        );
-        secret_nonces.insert(
-            self.take_2_transaction.tx().compute_txid(),
-            self.take_2_transaction.push_nonces(context),
-        );
-
-        secret_nonces
-    }
-
-    pub fn pre_sign(
-        &mut self,
-        context: &VerifierContext,
-        secret_nonces: &HashMap<Txid, HashMap<usize, SecNonce>>,
-    ) {
-        self.assert_transaction.pre_sign(
-            context,
-            &self.connector_b,
-            &secret_nonces[&self.assert_transaction.tx().compute_txid()],
-        );
-        self.disprove_chain_transaction.pre_sign(
-            context,
-            &self.connector_b,
-            &secret_nonces[&self.disprove_chain_transaction.tx().compute_txid()],
-        );
-        self.disprove_transaction.pre_sign(
-            context,
-            &self.connector_5,
-            &secret_nonces[&self.disprove_transaction.tx().compute_txid()],
-        );
-        self.kick_off_timeout_transaction.pre_sign(
-            context,
-            &self.connector_1,
-            &secret_nonces[&self.kick_off_timeout_transaction.tx().compute_txid()],
-        );
-        self.start_time_timeout_transaction.pre_sign(
-            context,
-            &self.connector_1,
-            &self.connector_2,
-            &secret_nonces[&self.start_time_timeout_transaction.tx().compute_txid()],
-        );
-        self.take_1_transaction.pre_sign(
-            context,
-            &self.connector_0,
-            &self.connector_b,
-            &secret_nonces[&self.take_1_transaction.tx().compute_txid()],
-        );
-        self.take_2_transaction.pre_sign(
-            context,
-            &self.connector_0,
-            &self.connector_5,
-            &secret_nonces[&self.take_2_transaction.tx().compute_txid()],
-        );
-
-        self.n_of_n_presigned = true; // TODO: set to true after collecting all n of n signatures
     }
 
     pub async fn verifier_status(&self, client: &AsyncClient) -> PegOutVerifierStatus {
@@ -1706,7 +1694,9 @@ impl PegOutGraph {
         }
     }
 
-    pub fn is_peg_out_initiated(&self) -> bool { return self.peg_out_chain_event.is_some(); }
+    pub fn is_peg_out_initiated(&self) -> bool {
+        return self.peg_out_chain_event.is_some();
+    }
 
     pub async fn match_and_set_peg_out_event(
         &mut self,
@@ -2027,6 +2017,51 @@ impl PegOutGraph {
             connector_b,
             connector_c,
         }
+    }
+
+    fn all_presigned_txs(&self) -> impl Iterator<Item = &dyn PreSignedMusig2Transaction> {
+        let all_txs: Vec<&dyn PreSignedMusig2Transaction> = vec![
+            &self.assert_transaction,
+            &self.disprove_chain_transaction,
+            &self.disprove_transaction,
+            &self.kick_off_timeout_transaction,
+            &self.start_time_timeout_transaction,
+            &self.take_1_transaction,
+            &self.take_2_transaction,
+        ];
+        all_txs.into_iter()
+    }
+
+    fn all_presigned_txs_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut dyn PreSignedMusig2Transaction> {
+        let all_txs: Vec<&mut dyn PreSignedMusig2Transaction> = vec![
+            &mut self.assert_transaction,
+            &mut self.disprove_chain_transaction,
+            &mut self.disprove_transaction,
+            &mut self.kick_off_timeout_transaction,
+            &mut self.start_time_timeout_transaction,
+            &mut self.take_1_transaction,
+            &mut self.take_2_transaction,
+        ];
+        all_txs.into_iter()
+    }
+
+    pub fn has_all_nonces_of(&self, context: &VerifierContext) -> bool {
+        self.all_presigned_txs()
+            .all(|x| x.has_nonces_for(context.verifier_public_key))
+    }
+    pub fn has_all_nonces(&self, verifier_pubkeys: &[PublicKey]) -> bool {
+        self.all_presigned_txs()
+            .all(|x| x.has_all_nonces(verifier_pubkeys))
+    }
+    pub fn has_all_signatures_of(&self, context: &VerifierContext) -> bool {
+        self.all_presigned_txs()
+            .all(|x| x.has_signatures_for(context.verifier_public_key))
+    }
+    pub fn has_all_signatures(&self, verifier_pubkeys: &[PublicKey]) -> bool {
+        self.all_presigned_txs()
+            .all(|x| x.has_all_signatures(verifier_pubkeys))
     }
 }
 

--- a/src/bridge/transactions/assert.rs
+++ b/src/bridge/transactions/assert.rs
@@ -63,6 +63,9 @@ impl PreSignedMusig2Transaction for AssertTransaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0]
+    }
 }
 
 impl AssertTransaction {
@@ -151,16 +154,6 @@ impl AssertTransaction {
             TapSighashType::All,
             connector_b.generate_taproot_spend_info(),
         );
-    }
-
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
     }
 
     pub fn pre_sign(

--- a/src/bridge/transactions/disprove.rs
+++ b/src/bridge/transactions/disprove.rs
@@ -63,6 +63,9 @@ impl PreSignedMusig2Transaction for DisproveTransaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0]
+    }
 }
 
 impl DisproveTransaction {
@@ -169,16 +172,6 @@ impl DisproveTransaction {
             TapSighashType::Single,
             connector_5.generate_taproot_spend_info(),
         );
-    }
-
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
     }
 
     pub fn pre_sign(

--- a/src/bridge/transactions/disprove_chain.rs
+++ b/src/bridge/transactions/disprove_chain.rs
@@ -62,6 +62,9 @@ impl PreSignedMusig2Transaction for DisproveChainTransaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0]
+    }
 }
 
 impl DisproveChainTransaction {
@@ -135,16 +138,6 @@ impl DisproveChainTransaction {
             TapSighashType::Single,
             connector_b.generate_taproot_spend_info(),
         );
-    }
-
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
     }
 
     pub fn pre_sign(

--- a/src/bridge/transactions/kick_off_timeout.rs
+++ b/src/bridge/transactions/kick_off_timeout.rs
@@ -62,6 +62,9 @@ impl PreSignedMusig2Transaction for KickOffTimeoutTransaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0]
+    }
 }
 
 impl KickOffTimeoutTransaction {
@@ -137,15 +140,6 @@ impl KickOffTimeoutTransaction {
         );
     }
 
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
-    }
 
     pub fn pre_sign(
         &mut self,

--- a/src/bridge/transactions/peg_in_confirm.rs
+++ b/src/bridge/transactions/peg_in_confirm.rs
@@ -63,6 +63,9 @@ impl PreSignedMusig2Transaction for PegInConfirmTransaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0]
+    }
 }
 
 impl PegInConfirmTransaction {
@@ -195,16 +198,6 @@ impl PegInConfirmTransaction {
             TapSighashType::All,
             connector_z.generate_taproot_spend_info(),
         );
-    }
-
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
     }
 
     pub fn pre_sign(

--- a/src/bridge/transactions/pre_signed_musig2.rs
+++ b/src/bridge/transactions/pre_signed_musig2.rs
@@ -18,7 +18,7 @@ use super::{
     },
 };
 
-pub trait PreSignedMusig2Transaction {
+pub trait PreSignedMusig2Transaction: PreSignedTransaction {
     fn musig2_nonces(&self) -> &HashMap<usize, HashMap<PublicKey, PubNonce>>;
     fn musig2_nonces_mut(&mut self) -> &mut HashMap<usize, HashMap<PublicKey, PubNonce>>;
     fn musig2_nonce_signatures(&self) -> &HashMap<usize, HashMap<PublicKey, Signature>>;
@@ -28,42 +28,70 @@ pub trait PreSignedMusig2Transaction {
     fn musig2_signatures_mut(
         &mut self,
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>>;
-}
-
-pub fn push_nonce<T: PreSignedTransaction + PreSignedMusig2Transaction>(
-    tx: &mut T,
-    context: &VerifierContext,
-    input_index: usize,
-) -> SecNonce {
-    // Push nonce
-    let musig2_nonces = tx.musig2_nonces_mut();
-    if musig2_nonces.get(&input_index).is_none() {
-        musig2_nonces.insert(input_index, HashMap::new());
+    fn verifier_inputs(&self) -> Vec<usize>;
+    fn has_nonces_for(&self, verifier_pubkey: PublicKey) -> bool {
+        self.has_all_nonces(&vec![verifier_pubkey])
+    }
+    fn has_all_nonces(&self, verifier_pubkeys: &[PublicKey]) -> bool {
+        self.verifier_inputs().into_iter().all(|input_index| {
+            verifier_pubkeys.into_iter().all(|pubkey| {
+                self.musig2_nonces().contains_key(&input_index)
+                    && self.musig2_nonces()[&input_index].contains_key(&pubkey)
+            })
+        })
+    }
+    fn has_signatures_for(&self, verifier_pubkey: PublicKey) -> bool {
+        self.has_all_signatures(&vec![verifier_pubkey])
+    }
+    fn has_all_signatures(&self, verifier_pubkeys: &[PublicKey]) -> bool {
+        self.verifier_inputs().into_iter().all(|input_index| {
+            verifier_pubkeys.into_iter().all(|pubkey| {
+                self.musig2_signatures().contains_key(&input_index)
+                    && self.musig2_signatures()[&input_index].contains_key(&pubkey)
+            })
+        })
+    }
+    fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
+        self.verifier_inputs().iter().map(|input_index| (
+          (*input_index,   self.push_nonce(context, *input_index))
+        )).collect()
     }
 
-    let secret_nonce = generate_nonce();
-    musig2_nonces
-        .get_mut(&input_index)
-        .unwrap()
-        .insert(context.verifier_public_key, secret_nonce.public_nonce());
-
-    // Sign the nonce and push the signature
-    let musig2_nonce_signatures = tx.musig2_nonce_signatures_mut();
-    if musig2_nonce_signatures.get(&input_index).is_none() {
-        musig2_nonce_signatures.insert(input_index, HashMap::new());
+    fn push_nonce(
+        &mut self,
+        context: &VerifierContext,
+        input_index: usize,
+    ) -> SecNonce {
+        // Push nonce
+        let musig2_nonces = self.musig2_nonces_mut();
+        if musig2_nonces.get(&input_index).is_none() {
+            musig2_nonces.insert(input_index, HashMap::new());
+        }
+    
+        let secret_nonce = generate_nonce();
+        musig2_nonces
+            .get_mut(&input_index)
+            .unwrap()
+            .insert(context.verifier_public_key, secret_nonce.public_nonce());
+    
+        // Sign the nonce and push the signature
+        let musig2_nonce_signatures = self.musig2_nonce_signatures_mut();
+        if musig2_nonce_signatures.get(&input_index).is_none() {
+            musig2_nonce_signatures.insert(input_index, HashMap::new());
+        }
+    
+        let nonce_signature = context.secp.sign_schnorr(
+            &get_nonce_message(&secret_nonce.public_nonce()),
+            &context.verifier_keypair,
+        );
+    
+        musig2_nonce_signatures
+            .get_mut(&input_index)
+            .unwrap()
+            .insert(context.verifier_public_key, nonce_signature);
+    
+        secret_nonce
     }
-
-    let nonce_signature = context.secp.sign_schnorr(
-        &get_nonce_message(&secret_nonce.public_nonce()),
-        &context.verifier_keypair,
-    );
-
-    musig2_nonce_signatures
-        .get_mut(&input_index)
-        .unwrap()
-        .insert(context.verifier_public_key, nonce_signature);
-
-    secret_nonce
 }
 
 pub fn get_nonce_message(nonce: &PubNonce) -> Message {

--- a/src/bridge/transactions/start_time.rs
+++ b/src/bridge/transactions/start_time.rs
@@ -65,6 +65,9 @@ impl PreSignedMusig2Transaction for StartTimeTransaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![]
+    }
 }
 
 impl StartTimeTransaction {

--- a/src/bridge/transactions/start_time_timeout.rs
+++ b/src/bridge/transactions/start_time_timeout.rs
@@ -32,17 +32,27 @@ pub struct StartTimeTimeoutTransaction {
 }
 
 impl PreSignedTransaction for StartTimeTimeoutTransaction {
-    fn tx(&self) -> &Transaction { &self.tx }
+    fn tx(&self) -> &Transaction {
+        &self.tx
+    }
 
-    fn tx_mut(&mut self) -> &mut Transaction { &mut self.tx }
+    fn tx_mut(&mut self) -> &mut Transaction {
+        &mut self.tx
+    }
 
-    fn prev_outs(&self) -> &Vec<TxOut> { &self.prev_outs }
+    fn prev_outs(&self) -> &Vec<TxOut> {
+        &self.prev_outs
+    }
 
-    fn prev_scripts(&self) -> &Vec<ScriptBuf> { &self.prev_scripts }
+    fn prev_scripts(&self) -> &Vec<ScriptBuf> {
+        &self.prev_scripts
+    }
 }
 
 impl PreSignedMusig2Transaction for StartTimeTimeoutTransaction {
-    fn musig2_nonces(&self) -> &HashMap<usize, HashMap<PublicKey, PubNonce>> { &self.musig2_nonces }
+    fn musig2_nonces(&self) -> &HashMap<usize, HashMap<PublicKey, PubNonce>> {
+        &self.musig2_nonces
+    }
     fn musig2_nonces_mut(&mut self) -> &mut HashMap<usize, HashMap<PublicKey, PubNonce>> {
         &mut self.musig2_nonces
     }
@@ -61,6 +71,9 @@ impl PreSignedMusig2Transaction for StartTimeTimeoutTransaction {
         &mut self,
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
+    }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0, 1]
     }
 }
 
@@ -198,20 +211,6 @@ impl StartTimeTimeoutTransaction {
             TapSighashType::None,
             connector_1.generate_taproot_spend_info(),
         );
-    }
-
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        let input_index = 1;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
     }
 
     pub fn pre_sign(

--- a/src/bridge/transactions/take_1.rs
+++ b/src/bridge/transactions/take_1.rs
@@ -65,6 +65,9 @@ impl PreSignedMusig2Transaction for Take1Transaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0, 3]
+    }
 }
 
 impl Take1Transaction {
@@ -252,20 +255,6 @@ impl Take1Transaction {
             TapSighashType::All,
             connector_b.generate_taproot_spend_info(),
         );
-    }
-
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        let input_index = 3;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
     }
 
     pub fn pre_sign(

--- a/src/bridge/transactions/take_2.rs
+++ b/src/bridge/transactions/take_2.rs
@@ -65,6 +65,10 @@ impl PreSignedMusig2Transaction for Take2Transaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
+    fn verifier_inputs(&self) -> Vec<usize> {
+        vec![0, 2]
+    }
+
 }
 
 impl Take2Transaction {
@@ -252,20 +256,6 @@ impl Take2Transaction {
             connector_c.generate_taproot_spend_info(),
             &vec![&context.operator_keypair],
         );
-    }
-
-    pub fn push_nonces(&mut self, context: &VerifierContext) -> HashMap<usize, SecNonce> {
-        let mut secret_nonces = HashMap::new();
-
-        let input_index = 0;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        let input_index = 2;
-        let secret_nonce = push_nonce(self, context, input_index);
-        secret_nonces.insert(input_index, secret_nonce);
-
-        secret_nonces
     }
 
     pub fn pre_sign(

--- a/tests/bridge/assert/assert.rs
+++ b/tests/bridge/assert/assert.rs
@@ -5,7 +5,7 @@ use bitvm::bridge::{
     graphs::base::ONE_HUNDRED,
     transactions::{
         assert::AssertTransaction,
-        base::{BaseTransaction, Input},
+        base::{BaseTransaction, Input}, pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
 

--- a/tests/bridge/client/musig2_peg_in.rs
+++ b/tests/bridge/client/musig2_peg_in.rs
@@ -57,7 +57,7 @@ async fn test_musig2_peg_in() {
     depositor_operator_verifier_0_client.sync().await;
 
     println!("Verifier 0: Generating nonces...");
-    depositor_operator_verifier_0_client.push_peg_in_nonces(&graph_id);
+    depositor_operator_verifier_0_client.push_verifier_nonces(&graph_id);
 
     println!("Verifier 0: Saving state changes to remote...");
     depositor_operator_verifier_0_client.flush().await;
@@ -67,7 +67,7 @@ async fn test_musig2_peg_in() {
     verifier_1_client.sync().await;
 
     println!("Verifier 1: Generating nonces...");
-    verifier_1_client.push_peg_in_nonces(&graph_id);
+    verifier_1_client.push_verifier_nonces(&graph_id);
 
     println!("Verifier 1: Saving state changes to remote...");
     verifier_1_client.flush().await;
@@ -77,7 +77,7 @@ async fn test_musig2_peg_in() {
     depositor_operator_verifier_0_client.sync().await;
 
     println!("Verifier 0: Pre-signing...");
-    depositor_operator_verifier_0_client.pre_sign_peg_in(&graph_id);
+    depositor_operator_verifier_0_client.push_verifier_signature(&graph_id);
 
     println!("Verifier 0: Saving state changes to remote...");
     depositor_operator_verifier_0_client.flush().await;
@@ -87,7 +87,7 @@ async fn test_musig2_peg_in() {
     verifier_1_client.sync().await;
 
     println!("Verifier 1: Pre-signing...");
-    verifier_1_client.pre_sign_peg_in(&graph_id);
+    verifier_1_client.push_verifier_signature(&graph_id);
 
     println!("Verifier 1: Saving state changes to remote...");
     verifier_1_client.flush().await;

--- a/tests/bridge/client/musig2_peg_out.rs
+++ b/tests/bridge/client/musig2_peg_out.rs
@@ -286,22 +286,22 @@ async fn create_peg_out_graph(
         .await;
 
     eprintln!("Verifier 0 push peg-out nonces");
-    depositor_operator_verifier_0_client.push_peg_out_nonces(&peg_out_graph_id);
+    depositor_operator_verifier_0_client.push_verifier_nonces(&peg_out_graph_id);
     depositor_operator_verifier_0_client.flush().await;
 
     eprintln!("Verifier 1 push peg-out nonces");
     verifier_1_client.sync().await;
-    verifier_1_client.push_peg_out_nonces(&peg_out_graph_id);
+    verifier_1_client.push_verifier_nonces(&peg_out_graph_id);
     verifier_1_client.flush().await;
 
     eprintln!("Verifier 0 pre-sign peg-out");
     depositor_operator_verifier_0_client.sync().await;
-    depositor_operator_verifier_0_client.pre_sign_peg_out(&peg_out_graph_id);
+    depositor_operator_verifier_0_client.push_verifier_signature(&peg_out_graph_id);
     depositor_operator_verifier_0_client.flush().await;
 
     eprintln!("Verifier 1 pre-sign peg-out");
     verifier_1_client.sync().await;
-    verifier_1_client.pre_sign_peg_out(&peg_out_graph_id);
+    verifier_1_client.push_verifier_signature(&peg_out_graph_id);
     verifier_1_client.flush().await;
 
     eprintln!("Broadcasting kick-off 1...");
@@ -398,19 +398,19 @@ async fn create_peg_in_graph(
         .await;
 
     client_0.broadcast_peg_in_deposit(&graph_id).await;
-    client_0.push_peg_in_nonces(&graph_id);
+    client_0.push_verifier_nonces(&graph_id);
     client_0.flush().await;
 
     client_1.sync().await;
-    client_1.push_peg_in_nonces(&graph_id);
+    client_1.push_verifier_nonces(&graph_id);
     client_1.flush().await;
 
     client_0.sync().await;
-    client_0.pre_sign_peg_in(&graph_id);
+    client_0.push_verifier_signature(&graph_id);
     client_0.flush().await;
 
     client_1.sync().await;
-    client_1.pre_sign_peg_in(&graph_id);
+    client_1.push_verifier_signature(&graph_id);
     client_1.flush().await;
 
     // Wait for peg-in deposit transaction to be mined

--- a/tests/bridge/disprove/disprove.rs
+++ b/tests/bridge/disprove/disprove.rs
@@ -12,7 +12,7 @@ mod tests {
         scripts::generate_pay_to_pubkey_script,
         transactions::{
             base::{BaseTransaction, Input},
-            disprove::DisproveTransaction,
+            disprove::DisproveTransaction, pre_signed_musig2::PreSignedMusig2Transaction,
         },
     };
 

--- a/tests/bridge/disprove_chain/disprove_chain.rs
+++ b/tests/bridge/disprove_chain/disprove_chain.rs
@@ -11,7 +11,7 @@ mod tests {
         scripts::generate_pay_to_pubkey_script,
         transactions::{
             base::{BaseTransaction, Input},
-            disprove_chain::DisproveChainTransaction,
+            disprove_chain::DisproveChainTransaction, pre_signed_musig2::PreSignedMusig2Transaction,
         },
     };
 

--- a/tests/bridge/integration/peg_in/peg_in.rs
+++ b/tests/bridge/integration/peg_in/peg_in.rs
@@ -10,7 +10,7 @@ use bitvm::bridge::{
     client::client::BitVMClient,
     connectors::{base::TaprootConnector, connector_0::Connector0},
     graphs::{
-        base::{FEE_AMOUNT, INITIAL_AMOUNT},
+        base::{BaseGraph, FEE_AMOUNT, INITIAL_AMOUNT},
         peg_in::PegInVerifierStatus,
     },
     scripts::generate_pay_to_pubkey_script_address,
@@ -19,6 +19,7 @@ use bitvm::bridge::{
         peg_in_confirm::PegInConfirmTransaction,
         peg_in_deposit::PegInDepositTransaction,
         peg_in_refund::PegInRefundTransaction,
+        pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
 use esplora_client::Error;
@@ -301,12 +302,28 @@ async fn test_peg_in_graph_automatic_verifier() {
         b.merge_data(a.get_data().clone());
     };
     let graph = |client: &BitVMClient| client.get_data().peg_in_graphs[0].clone();
-
+    let pegouts_of = |client: &BitVMClient| {
+        let pegin = graph(client);
+        pegin
+            .peg_out_graphs
+            .iter()
+            .map(|id| {
+                client
+                    .get_data()
+                    .peg_out_graphs
+                    .iter()
+                    .find(|peg_out| peg_out.id() == id)
+                    .unwrap()
+                    .clone()
+            })
+            .collect::<Vec<_>>()
+    };
     // set up data
     let mut config = setup_test().await;
     let deposit_input = get_pegin_input(&config, INITIAL_AMOUNT + FEE_AMOUNT * 2).await;
     let client_0 = &mut config.client_0;
     let client_1 = &mut config.client_1;
+    let operator = &mut config.operator_context;
     let esplora = client_0.esplora.clone();
     let context = Some(&config.verifier_0_context);
 
@@ -315,43 +332,80 @@ async fn test_peg_in_graph_automatic_verifier() {
         .create_peg_in_graph(deposit_input, "0000000000000000000000000000000000000000")
         .await;
     assert_eq!(
-        graph(client_0).verifier_status(&esplora, context).await,
+        graph(client_0)
+            .verifier_status(&esplora, context, &[])
+            .await,
         PegInVerifierStatus::AwaitingDeposit
     );
 
     // wait peg-in deposit and wait for the tx to be confirmed (which will set status to PegInPendingOurNonces)
     client_0.process_peg_in_as_depositor(&graph(client_0)).await;
     loop {
-        if graph(client_0).verifier_status(&esplora, context).await
-            == PegInVerifierStatus::PendingOurNonces
-        {
+        if !matches!(
+            graph(client_0)
+                .verifier_status(&esplora, context, &[])
+                .await,
+            PegInVerifierStatus::AwaitingDeposit
+        ) {
             break;
         }
         println!("Awaiting confirmation...");
         sleep(Duration::from_secs(1)).await;
     }
 
+    assert_eq!(
+        graph(client_0)
+            .verifier_status(&esplora, context, &[])
+            .await,
+        PegInVerifierStatus::AwaitingPegOutCreation
+    );
+
+    // make operator submit a pegout graph & check that status changes to PegInWait
+    client_0.process_peg_in_as_operator(&graph(client_0)).await;
+    let peg_out_graph = client_0
+        .get_data()
+        .peg_out_graphs
+        .get(0)
+        .expect("peg out should have been created above")
+        .clone();
+    let peg_out_graph_id = peg_out_graph.id();
+    assert_eq!(
+        graph(client_0)
+            .verifier_status(&esplora, context, &pegouts_of(client_0).iter().collect::<Vec<_>>())
+            .await,
+        PegInVerifierStatus::PendingOurNonces(vec![
+            peg_out_graph_id.clone(),
+            graph(client_0).id().clone()
+        ])
+    );
+
     // submit client_0 nonce & check that status changes to PegInAwaitingNonces
     client_0.process_peg_in_as_verifier(&graph(client_0)).await;
     sync(client_0, client_1);
     assert_eq!(
-        graph(client_0).verifier_status(&esplora, context).await,
+        graph(client_0)
+            .verifier_status(&esplora, context, &pegouts_of(client_0).iter().collect::<Vec<_>>())
+            .await,
         PegInVerifierStatus::AwaitingNonces
     );
 
     // submit client_1 nonce & check that status changes to PegInPendingOurSignature
     client_1.process_peg_in_as_verifier(&graph(client_0)).await;
     sync(client_0, client_1);
-    assert_eq!(
-        graph(client_0).verifier_status(&esplora, context).await,
-        PegInVerifierStatus::PendingOurSignature
-    );
+    assert!(matches!(
+        graph(client_0)
+            .verifier_status(&esplora, context, &pegouts_of(client_0).iter().collect::<Vec<_>>())
+            .await,
+        PegInVerifierStatus::PendingOurSignature(_)
+    ));
 
     // submit client_0 signature & check that status changes to PegInAwaitingSignatures
     client_0.process_peg_in_as_verifier(&graph(client_0)).await;
     sync(client_0, client_1);
     assert_eq!(
-        graph(client_0).verifier_status(&esplora, context).await,
+        graph(client_0)
+            .verifier_status(&esplora, context, &pegouts_of(client_0).iter().collect::<Vec<_>>())
+            .await,
         PegInVerifierStatus::AwaitingSignatures
     );
 
@@ -359,14 +413,19 @@ async fn test_peg_in_graph_automatic_verifier() {
     client_1.process_peg_in_as_verifier(&graph(client_0)).await;
     sync(client_0, client_1);
     assert_eq!(
-        graph(client_0).verifier_status(&esplora, context).await,
+        graph(client_0)
+            .verifier_status(&esplora, context, &pegouts_of(client_0).iter().collect::<Vec<_>>())
+            .await,
         PegInVerifierStatus::ReadyToSubmit
     );
 
     // submit confirm tx & check that status changes to PegInComplete
     client_0.process_peg_in_as_verifier(&graph(client_0)).await;
     loop {
-        if graph(client_0).verifier_status(&esplora, context).await == PegInVerifierStatus::Complete
+        if graph(client_0)
+            .verifier_status(&esplora, context, &pegouts_of(client_0).iter().collect::<Vec<_>>())
+            .await
+            == PegInVerifierStatus::Complete
         {
             break;
         }

--- a/tests/bridge/integration/peg_out/disprove.rs
+++ b/tests/bridge/integration/peg_out/disprove.rs
@@ -5,7 +5,7 @@ use bitvm::bridge::{
     transactions::{
         assert::AssertTransaction,
         base::{BaseTransaction, Input},
-        disprove::DisproveTransaction,
+        disprove::DisproveTransaction, pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
 

--- a/tests/bridge/integration/peg_out/disprove_chain.rs
+++ b/tests/bridge/integration/peg_out/disprove_chain.rs
@@ -7,7 +7,7 @@ use bitvm::bridge::{
     scripts::generate_pay_to_pubkey_script_address,
     transactions::{
         base::{BaseTransaction, Input},
-        disprove_chain::DisproveChainTransaction,
+        disprove_chain::DisproveChainTransaction, pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
 

--- a/tests/bridge/integration/peg_out/kick_off_timeout.rs
+++ b/tests/bridge/integration/peg_out/kick_off_timeout.rs
@@ -8,7 +8,7 @@ use bitvm::bridge::{
     scripts::generate_pay_to_pubkey_script_address,
     transactions::{
         base::{BaseTransaction, Input},
-        kick_off_timeout::KickOffTimeoutTransaction,
+        kick_off_timeout::KickOffTimeoutTransaction, pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
 

--- a/tests/bridge/integration/peg_out/start_time_timeout.rs
+++ b/tests/bridge/integration/peg_out/start_time_timeout.rs
@@ -6,8 +6,7 @@ use bitvm::bridge::{
     graphs::base::{FEE_AMOUNT, INITIAL_AMOUNT},
     scripts::generate_pay_to_pubkey_script_address,
     transactions::{
-        base::{BaseTransaction, Input},
-        start_time_timeout::StartTimeTimeoutTransaction,
+        base::{BaseTransaction, Input}, pre_signed_musig2::PreSignedMusig2Transaction, start_time_timeout::StartTimeTimeoutTransaction
     },
 };
 

--- a/tests/bridge/integration/peg_out/take_1.rs
+++ b/tests/bridge/integration/peg_out/take_1.rs
@@ -6,9 +6,7 @@ use bitvm::bridge::{
     graphs::base::{FEE_AMOUNT, INITIAL_AMOUNT},
     scripts::generate_pay_to_pubkey_script_address,
     transactions::{
-        base::{BaseTransaction, Input},
-        kick_off_2::KickOff2Transaction,
-        take_1::Take1Transaction,
+        base::{BaseTransaction, Input}, kick_off_2::KickOff2Transaction, pre_signed_musig2::PreSignedMusig2Transaction, take_1::Take1Transaction
     },
 };
 use tokio::time::sleep;

--- a/tests/bridge/integration/peg_out/take_2.rs
+++ b/tests/bridge/integration/peg_out/take_2.rs
@@ -6,8 +6,7 @@ use bitvm::bridge::{
     graphs::base::{FEE_AMOUNT, INITIAL_AMOUNT},
     scripts::generate_pay_to_pubkey_script_address,
     transactions::{
-        base::{BaseTransaction, Input},
-        take_2::Take2Transaction,
+        base::{BaseTransaction, Input}, pre_signed_musig2::PreSignedMusig2Transaction, take_2::Take2Transaction
     },
 };
 use tokio::time::sleep;

--- a/tests/bridge/integration/peg_out/utils.rs
+++ b/tests/bridge/integration/peg_out/utils.rs
@@ -11,12 +11,7 @@ use bitvm::bridge::{
     contexts::{depositor::DepositorContext, operator::OperatorContext, verifier::VerifierContext},
     graphs::peg_out::CommitmentMessageId,
     transactions::{
-        assert::AssertTransaction,
-        base::{BaseTransaction, Input},
-        kick_off_1::KickOff1Transaction,
-        kick_off_2::KickOff2Transaction,
-        peg_in_confirm::PegInConfirmTransaction,
-        signing_winternitz::{WinternitzPublicKey, WinternitzPublicKeyVariant, WinternitzSecret},
+        assert::AssertTransaction, base::{BaseTransaction, Input}, kick_off_1::KickOff1Transaction, kick_off_2::KickOff2Transaction, peg_in_confirm::PegInConfirmTransaction, pre_signed_musig2::PreSignedMusig2Transaction, signing_winternitz::{WinternitzPublicKey, WinternitzPublicKeyVariant, WinternitzSecret}
     },
 };
 

--- a/tests/bridge/kick_off_timeout/kick_off_timeout.rs
+++ b/tests/bridge/kick_off_timeout/kick_off_timeout.rs
@@ -5,7 +5,7 @@ use bitvm::bridge::{
     graphs::base::ONE_HUNDRED,
     transactions::{
         base::{BaseTransaction, Input},
-        kick_off_timeout::KickOffTimeoutTransaction,
+        kick_off_timeout::KickOffTimeoutTransaction, pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
 

--- a/tests/bridge/peg_in/peg_in_confirm.rs
+++ b/tests/bridge/peg_in/peg_in_confirm.rs
@@ -5,7 +5,7 @@ use bitvm::bridge::{
     graphs::base::{FEE_AMOUNT, INITIAL_AMOUNT},
     transactions::{
         base::{BaseTransaction, Input},
-        peg_in_confirm::PegInConfirmTransaction,
+        peg_in_confirm::PegInConfirmTransaction, pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
 

--- a/tests/bridge/serialization/assert_transaction.rs
+++ b/tests/bridge/serialization/assert_transaction.rs
@@ -4,7 +4,7 @@ use bitvm::bridge::{
     connectors::base::TaprootConnector,
     graphs::base::ONE_HUNDRED,
     serialization::{deserialize, serialize},
-    transactions::{assert::AssertTransaction, base::Input},
+    transactions::{assert::AssertTransaction, base::Input, pre_signed_musig2::PreSignedMusig2Transaction},
 };
 
 use super::super::{helper::generate_stub_outpoint, setup::setup_test};

--- a/tests/bridge/start_time_timeout/start_time_timeout.rs
+++ b/tests/bridge/start_time_timeout/start_time_timeout.rs
@@ -4,8 +4,7 @@ use bitvm::bridge::{
     connectors::base::TaprootConnector,
     graphs::base::{DUST_AMOUNT, ONE_HUNDRED},
     transactions::{
-        base::{BaseTransaction, Input},
-        start_time_timeout::StartTimeTimeoutTransaction,
+        base::{BaseTransaction, Input}, pre_signed_musig2::PreSignedMusig2Transaction, start_time_timeout::StartTimeTimeoutTransaction
     },
 };
 

--- a/tests/bridge/take_1/take_1.rs
+++ b/tests/bridge/take_1/take_1.rs
@@ -4,8 +4,7 @@ use bitvm::bridge::{
     connectors::base::{P2wshConnector, TaprootConnector},
     graphs::base::{DUST_AMOUNT, FEE_AMOUNT, INITIAL_AMOUNT, ONE_HUNDRED},
     transactions::{
-        base::{BaseTransaction, Input},
-        take_1::Take1Transaction,
+        base::{BaseTransaction, Input}, pre_signed_musig2::PreSignedMusig2Transaction, take_1::Take1Transaction
     },
 };
 

--- a/tests/bridge/take_2/take_2.rs
+++ b/tests/bridge/take_2/take_2.rs
@@ -4,8 +4,7 @@ use bitvm::bridge::{
     connectors::base::{P2wshConnector, TaprootConnector},
     graphs::base::{DUST_AMOUNT, FEE_AMOUNT, INITIAL_AMOUNT, ONE_HUNDRED},
     transactions::{
-        base::{BaseTransaction, Input},
-        take_2::Take2Transaction,
+        base::{BaseTransaction, Input}, pre_signed_musig2::PreSignedMusig2Transaction, take_2::Take2Transaction
     },
 };
 


### PR DESCRIPTION
This PR adds the construction and signing of peg-out graphs to the peg-in creation process. For now, it waits until `NUM_REQUIRED_OPERATORS` operators have created peg-out graphs, but this should probably be made more dynamic in the future. 

Usage remains the same as in https://github.com/elementlabs42/BitVM-playground/pull/86 but under the hood, the process is now as follows:

- Peg-in graph is created by depositor
- Operators create peg-outs
- Verifiers sign the peg-outs and the peg-in-confirm transactions
- peg-in-confirm tx is broadcasted

As part of this PR, I made some refactorings that allows to us to abstract over graphs & transactions. Concretely, some new methods were added to `BaseGraph` and `PreSignedMusig2Transaction` which are now used by the code.

See also the new `merge_hash_maps` function - that's easy to miss with the other refactorings.

